### PR TITLE
Update module path to Opsview fork

### DIFF
--- a/timeseries/cmd/influxdb-queries.go
+++ b/timeseries/cmd/influxdb-queries.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"github.com/ajgb/go-opsview/timeseries"
+	"github.com/ITRS-Group/opsview-go/timeseries"
 )
 
 func main() {

--- a/timeseries/cmd/influxdb-updates.go
+++ b/timeseries/cmd/influxdb-updates.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"github.com/ajgb/go-opsview/timeseries"
+	"github.com/ITRS-Group/opsview-go/timeseries"
 )
 
 func main() {


### PR DESCRIPTION
In order to correctly build directly from the fork, we update the module name in the ./cmd source files.

Signed-off-by: Jacob Hansen <jhansen@itrsgroup.com>